### PR TITLE
fix: error message with example message

### DIFF
--- a/example.lua
+++ b/example.lua
@@ -2,6 +2,3 @@ term.setBackgroundColor(colors.white)
 term.clear()
 term.setTextColor(colors.black)
 bigfont.writeOn(term.current(), 1, "Server shutdown on 9/27/24", 5, 3)
-while true do
-  sleep()
-end


### PR DESCRIPTION
By default, unless modified, quickslide does not give images access to `sleep()`, and instead refreshes at the interval set in the config file. As a result, the following error repeats itself while the computer is running:

![image](https://github.com/user-attachments/assets/768e6558-4b3c-43eb-8e2d-d64e4232fe7f)
